### PR TITLE
Solved field constructor bug when using option element.

### DIFF
--- a/src/main/java/tigase/form/Field.java
+++ b/src/main/java/tigase/form/Field.java
@@ -244,7 +244,7 @@ public class Field
 					if (v != null) {
 						valueList.add(v);
 					}
-				} else if ("value".equals(element.getName())) {
+				} else if ("option".equals(element.getName())) {
 					optionsLabelList.add(element.getAttributeStaticStr("label"));
 
 					Element v = element.getChild("value");


### PR DESCRIPTION
With the current constructor implementation, it is impossible to use the option element name. This fix solves that bug.